### PR TITLE
Changes from background agent bc-c426b2d3-a068-4549-8d15-386834b61f59

### DIFF
--- a/screens/RegistrationScreen.js
+++ b/screens/RegistrationScreen.js
@@ -547,7 +547,7 @@ export default function RegistrationScreen({ navigation, isProductionMode }) {
       console.log(`URL: ${API_BASE_URL}/register`);
 
       // Ajuste para fuso horário de Brasília (UTC-3)
-      const nowBrasilia = new Date(Date.now() - (3 * 60 * 60 * 1000));
+      const nowBrasilia = new Date(Date.now());
       const startTime = nowBrasilia.getTime();
 
       const response = await fetch(`${API_BASE_URL}/register`, {
@@ -562,7 +562,7 @@ export default function RegistrationScreen({ navigation, isProductionMode }) {
         signal: createTimeoutSignal(30000), // 30 segundos
       });
 
-      const endBrasilia = new Date(Date.now() - (3 * 60 * 60 * 1000));
+      const endBrasilia = new Date(Date.now());
       const endTime = endBrasilia.getTime();
       const requestDuration = endTime - startTime;
 
@@ -676,7 +676,7 @@ export default function RegistrationScreen({ navigation, isProductionMode }) {
       console.log('URL:', localUrl);
 
       // Ajuste para fuso horário de Brasília (UTC-3)
-      const nowBrasilia = new Date(Date.now() - (3 * 60 * 60 * 1000));
+      const nowBrasilia = new Date(Date.now());
       const startTime = nowBrasilia.getTime();
 
       let response;
@@ -700,7 +700,7 @@ export default function RegistrationScreen({ navigation, isProductionMode }) {
         throw err;
       }
 
-      const endBrasilia = new Date(Date.now() - (3 * 60 * 60 * 1000));
+      const endBrasilia = new Date(Date.now());
       const endTime = endBrasilia.getTime();
       const requestDuration = endTime - startTime;
 


### PR DESCRIPTION
Remove hardcoded UTC-3 timezone offset from `Date.now()` calls.

This ensures that `Date.now()` accurately reflects the current local time, instead of always subtracting 3 hours, which could lead to incorrect timestamps if the device's timezone is not UTC-3.

---
<a href="https://cursor.com/background-agent?bcId=bc-c426b2d3-a068-4549-8d15-386834b61f59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c426b2d3-a068-4549-8d15-386834b61f59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

