### PR TITLE
Adapt registration form for mobile

### DIFF
--- a/components/QRCodeScanner.js
+++ b/components/QRCodeScanner.js
@@ -181,11 +181,13 @@ export default function QRCodeScanner({ visible, onClose, onSuccess, onAlreadyDo
         console.log('MODO PRODUÇÃO - enviando para /activity/validate');
         
         const prodBody = JSON.stringify({
-          cpf: data.trim(),
+          is_foreign: false,
+          id_type: 'cpf',
+          id_number: data.trim(),
           method: 'qrcode',
           stand_name: standName.toLowerCase(),
           tablet_name: tabletName,
-          client_created_at: generateClientAttemptAt(),
+          client_validated_at: generateClientAttemptAt(),
         });
 
         response = await fetch(`${API_BASE_URL}/activity/validate`, {
@@ -208,10 +210,12 @@ export default function QRCodeScanner({ visible, onClose, onSuccess, onAlreadyDo
         
       } else {
         // MODO LOCAL
-        console.log('MODO LOCAL - enviando para /activity-qr');
-        
+        console.log('MODO LOCAL - enviando para /activity/validate');
+
         const localBody = JSON.stringify({
-          cpf: data.trim(),
+          is_foreign: false,
+          id_type: 'cpf',
+          id_number: data.trim(),
           method: 'qrcode',
           stand_name: standName.toLowerCase(),
           tablet_name: tabletName,
@@ -220,8 +224,8 @@ export default function QRCodeScanner({ visible, onClose, onSuccess, onAlreadyDo
 
         const localBaseUrl = await ConfigStorage.getLocalBaseUrl();
         const normalizedBaseUrl = localBaseUrl ? localBaseUrl.replace(/\/$/, '') : '';
-        const localUrl = `${normalizedBaseUrl}/activity-qr`;
-        
+        const localUrl = `${normalizedBaseUrl}/activity/validate`;
+
         response = await fetch(localUrl, {
           method: 'POST',
           headers: {


### PR DESCRIPTION
Add nationality switch and update API payloads to support Brazilian (CPF) and Foreigner (Passport) registration.

This PR introduces a nationality toggle in the registration flow, dynamically switching between CPF and Passport inputs. It updates the request bodies for `/register`, `/cpf/status`, and `/activity/validate` to correctly send `is_foreign`, `id_type`, and `id_number` based on the selected nationality, ensuring compliance with the new API specifications for both local and production environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1666701-041a-4586-824f-b4127bdecf1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1666701-041a-4586-824f-b4127bdecf1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

