### PR TITLE
Fix qr code data passing in request

### DIFF
--- a/components/QRCodeScanner.js
+++ b/components/QRCodeScanner.js
@@ -299,15 +299,16 @@ export default function QRCodeScanner({ visible, onClose, onSuccess, onAlreadyDo
       return;
     }
 
-    // Valida se o data não está vazio
-    if (!data || data.trim() === '') {
+    // Normaliza e valida o dado lido
+    const scannedValue = typeof data === 'string' ? data.trim() : String(data ?? '').trim();
+    if (!scannedValue) {
       console.log('QR Code vazio ignorado');
       return;
     }
 
-    console.log('QR Code lido:', { data, type });
+    console.log('QR Code lido:', { data: scannedValue, type });
     setScanned(true);
-    setScannedData(data.trim());
+    setScannedData(scannedValue);
 
     // Mostra confirmação antes de registrar
     Alert.alert(
@@ -346,7 +347,8 @@ export default function QRCodeScanner({ visible, onClose, onSuccess, onAlreadyDo
               resetStates();
             }, 10000);
 
-            await registerActivity(scannedData);
+            // Usa o valor lido imediatamente, evitando condição de corrida com setState
+            await registerActivity(scannedValue);
           }
         }
       ]


### PR DESCRIPTION
Fix QR code data being null/undefined in requests by passing the scanned value directly, avoiding asynchronous state issues.

The `scannedData` state was being updated asynchronously with `setScannedData`, but then immediately used within an `Alert.alert` callback. This created a race condition where `registerActivity` might be called before `scannedData` was updated, leading to `null` or `undefined` data being sent in the request. The fix ensures the immediately available `scannedValue` is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ad3ce1d-2743-4594-8f15-32a08e51a45f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ad3ce1d-2743-4594-8f15-32a08e51a45f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

